### PR TITLE
update Todo type to Prisma generated type

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,5 @@
 import useSWR, { mutate } from "swr";
-import { Todo } from "./types";
+import { Todo } from '@prisma/client'
 
 const todoPath = "/api/todos";
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,7 +3,7 @@ import Head from "next/head";
 import { useMemo, useState } from "react";
 import { createTodo, deleteTodo, toggleTodo, useTodos } from "../api";
 import styles from "../styles/Home.module.css";
-import { Todo } from "../types";
+import { Todo } from "@prisma/client";
 
 export const TodoList: React.FC = () => {
   const { data: todos, error } = useTodos();


### PR DESCRIPTION
The Todo type in this repo had an incorrect field: `created`. We could easily fix this type, but it actually isn't the correct way to use Prisma.

One of the main benefits of using Prisma is that the schema generates types for you. If we import the Todo type from the Prisma client, it will always stay up to date with the schema.